### PR TITLE
Iteration5

### DIFF
--- a/src/main/JungleBeat.java
+++ b/src/main/JungleBeat.java
@@ -1,5 +1,9 @@
 package main;
 
 public class JungleBeat {
-
+	public LinkedList list;
+	
+	public JungleBeat() {
+		list = new LinkedList();
+	}
 }

--- a/src/main/JungleBeat.java
+++ b/src/main/JungleBeat.java
@@ -1,0 +1,5 @@
+package main;
+
+public class JungleBeat {
+
+}

--- a/src/main/JungleBeat.java
+++ b/src/main/JungleBeat.java
@@ -6,4 +6,8 @@ public class JungleBeat {
 	public JungleBeat() {
 		list = new LinkedList();
 	}
+	
+	public String append(String data) {
+		return data;
+	}
 }

--- a/src/main/JungleBeat.java
+++ b/src/main/JungleBeat.java
@@ -1,5 +1,7 @@
 package main;
 
+import java.util.ArrayList;
+
 public class JungleBeat {
 	public LinkedList list;
 	
@@ -8,6 +10,11 @@ public class JungleBeat {
 	}
 	
 	public String append(String data) {
+		String[] temporary = data.split(" ");
+		
+		for(String soloData : temporary) {
+			list.append(soloData);
+		}
 		return data;
 	}
 }

--- a/src/test/JungleBeatTest.java
+++ b/src/test/JungleBeatTest.java
@@ -1,0 +1,18 @@
+package test;
+import main.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+class JungleBeatTest {
+
+	@Test
+	void testForInstanceOfJungleBeatClass() {
+		JungleBeat jb = new JungleBeat();
+		
+		Assert.assertNotNull(jb);
+	}
+
+}

--- a/src/test/JungleBeatTest.java
+++ b/src/test/JungleBeatTest.java
@@ -35,4 +35,17 @@ class JungleBeatTest {
 		
 		Assert.assertEquals("deep doo ditt", jb.append("deep doo ditt"));
 	}
+	
+	@Test
+	void testThatAppendFormatsTheData() {
+		JungleBeat jb = new JungleBeat();
+		jb.append("deep doo ditt");
+		
+		Assert.assertEquals("deep", jb.list.head.data);
+		Assert.assertEquals("doo", jb.list.head.next_node.data);
+		
+		jb.append("woo hoo shu");
+		
+		Assert.assertEquals(6, jb.list.count());
+	}
 }

--- a/src/test/JungleBeatTest.java
+++ b/src/test/JungleBeatTest.java
@@ -14,5 +14,10 @@ class JungleBeatTest {
 		
 		Assert.assertNotNull(jb);
 	}
-
+	@Test
+	void testForListAttribute() {
+		JungleBeat jb = new JungleBeat();
+		
+		Assert.assertEquals(LinkedList.class, jb.list.getClass());
+	}
 }

--- a/src/test/JungleBeatTest.java
+++ b/src/test/JungleBeatTest.java
@@ -28,4 +28,11 @@ class JungleBeatTest {
 		
 		Assert.assertNull(jb.list.head);
 	}
+	
+	@Test
+	void testThatDataIsFormattedBeforeGoingToLinkedListClass() {
+		JungleBeat jb = new JungleBeat();
+		
+		Assert.assertEquals("deep doo ditt", jb.append("deep doo ditt"));
+	}
 }

--- a/src/test/JungleBeatTest.java
+++ b/src/test/JungleBeatTest.java
@@ -14,10 +14,18 @@ class JungleBeatTest {
 		
 		Assert.assertNotNull(jb);
 	}
+	
 	@Test
 	void testForListAttribute() {
 		JungleBeat jb = new JungleBeat();
 		
 		Assert.assertEquals(LinkedList.class, jb.list.getClass());
+	}
+	
+	@Test
+	void testThatListStartsOutEmpty() {
+		JungleBeat jb = new JungleBeat();
+		
+		Assert.assertNull(jb.list.head);
 	}
 }


### PR DESCRIPTION
Iteration 5 of JungleBeat concerns making a JungleBeat class, and adding an append method.  The requirements for this iteration are located at [Iteration 5](https://backend.turing.edu/module1/projects/jungle_beat/iteration_5)

- [x] Wrote Tests
- [x] Implemented
- [] Reviewed

# Necessary checkmarks:
- [x] All Tests are Passing
- [] The code will run locally

## Type of change
- [x] New feature
- [] Bug Fix

# Implements/Fixes:
## Description of Changes:

This iteration adds a JungleBeat class.  The first test is checking for the presence of the class.  

When the JungleBeat class is instantiated, it creates a LinkedList class.  The second test checks for the presence of the LinkedList object.  The code is written such that a JungleBeat constructor creates a LinkedList object on instantiation.

The third test verifies that the newly created LinkedList object starts out empty (head is null).

One of the requirements for the JungleBeat class is that it should be able to format the data that is used to created nodes in the linked list.  That is, the JungleBeat append() method should break up space separated strings so that only one word is inserted per node.  The fourth and fifth tests verify this operation.

closes # N/A

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed (Please describe happened)

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

# Test Coverage:

- Overall coverage: 99.8%

